### PR TITLE
Add Debug Web UI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,7 @@
 
 # Distribution / packaging
 **/.Python
+**/.venv
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/docker/qna.dockerfile
+++ b/docker/qna.dockerfile
@@ -4,6 +4,8 @@ WORKDIR /app
 
 RUN pip install tensorflow_hub scipy sentence_transformers gensim questionary
 
+RUN python -c "import tensorflow_hub as hub; hub.load('https://tfhub.dev/google/universal-sentence-encoder/4')"
+
 COPY ./qna/src ./
 
 EXPOSE 8080

--- a/frontend/debug-styles.css
+++ b/frontend/debug-styles.css
@@ -1,0 +1,42 @@
+@import url("https://fonts.googleapis.com/css2?family=Roboto");
+
+html,
+body {
+    margin: 0;
+    padding: 0;
+    font-family: "Roboto", sans-serif;
+}
+
+.nav {
+    position: sticky;
+    top: 0;
+    box-shadow: 0px 0px 0.5em #00000017;
+    padding: 0.5em;
+    background: white
+}
+
+table {
+    color: #333;
+    background: white;
+    border: 1px solid grey;
+    font-size: 12pt;
+    border-collapse: collapse;
+    width: 100%;
+    text-align: center;
+}
+
+table thead th,
+table tfoot th {
+    color: #777;
+    background: rgba(0, 0, 0, 0.1);
+}
+
+table caption {
+    padding: 0.5em;
+}
+
+table th,
+table td {
+    padding: 0.5em;
+    border: 1px solid lightgrey;
+}

--- a/frontend/debug.html
+++ b/frontend/debug.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <link rel="stylesheet" href="debug-styles.css" />
+        <title>Debug View</title>
+    </head>
+    <body>
+        <div class="nav">
+            <div class="form-group">
+                <label for="askquestion">
+                    Enter a subject-line for your question:
+                </label>
+                <input
+                    type="text"
+                    id="askquestion"
+                    name="askquestion"
+                    value="Lab 1 help"
+                    oninput="onQuestionInputChange()"
+                />
+            </div>
+        </div>
+        <div>
+            <table>
+                <thead>
+                    <tr>
+                        <th>Suggestion</th>
+                        <th>cosine</th>
+                        <th>Further info</th>
+                    </tr>
+                </thead>
+                <tbody id="suggestiontable">
+                    <tr>
+                        <td>Question</td>
+                        <td>1.0</td>
+                        <td>More information</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+
+        <script>
+            let fetchSuggestionsTimeout = null;
+
+            async function fetchSuggestions() {
+                const questionText =
+                    document.getElementById("askquestion").value;
+
+                const res = await fetch(`/api/question/${questionText}`);
+
+                if (!res.ok) {
+                    return;
+                }
+
+                const data = await res.json();
+
+                const matches = data.matches;
+
+                suggestionTableBody = document.getElementById("suggestiontable");
+
+                suggestionTableBody.innerHTML = "";
+
+                for (let i = 1; i <= matches.length; i++) {
+                    let suggestionRowElement = document.createElement("tr");
+
+                    let suggestionTextElement = document.createElement("td");
+                    suggestionTextElement.innerHTML = matches[i];
+
+                    let cosineElement = document.createElement("td");
+                    cosineElement.innerHTML = Math.random();
+
+                    suggestionRowElement.appendChild(suggestionTextElement);
+                    suggestionRowElement.appendChild(cosineElement);
+                    suggestionRowElement.appendChild(document.createElement("td"));
+
+                    suggestionTableBody.appendChild(suggestionRowElement);
+                }
+            }
+
+            function onQuestionInputChange() {
+                if (fetchSuggestionsTimeout) {
+                    clearTimeout(fetchSuggestionsTimeout);
+                }
+
+                fetchSuggestionsTimeout = setTimeout(fetchSuggestions, 190);
+            }
+
+            fetchSuggestions();
+        </script>
+    </body>
+</html>

--- a/frontend/debug.html
+++ b/frontend/debug.html
@@ -27,15 +27,13 @@
                 <thead>
                     <tr>
                         <th>Suggestion</th>
-                        <th>cosine</th>
-                        <th>Further info</th>
+                        <th>Similarity</th>
                     </tr>
                 </thead>
                 <tbody id="suggestiontable">
                     <tr>
                         <td>Question</td>
                         <td>1.0</td>
-                        <td>More information</td>
                     </tr>
                 </tbody>
             </table>
@@ -73,7 +71,6 @@
 
                     suggestionRowElement.appendChild(suggestionTextElement);
                     suggestionRowElement.appendChild(cosineElement);
-                    suggestionRowElement.appendChild(document.createElement("td"));
 
                     suggestionTableBody.appendChild(suggestionRowElement);
                 }

--- a/frontend/debug.html
+++ b/frontend/debug.html
@@ -21,6 +21,20 @@
                     oninput="onQuestionInputChange()"
                 />
             </div>
+            <div class="form-group">
+                <label for="similarity-slider">Min similarity:</label>
+                <input
+                    type="range"
+                    id="similarity-slider"
+                    name="similarity-slider"
+                    min="-1"
+                    max="1"
+                    value="0"
+                    step="0.01"
+                    oninput="onSimilaritySliderChange()"
+                />
+                <span id="slider-label"> 0.00 </span>
+            </div>
         </div>
         <div>
             <table>
@@ -46,6 +60,9 @@
                 const questionText =
                     document.getElementById("askquestion").value;
 
+                const similaritySliderValue =
+                    document.getElementById("similarity-slider").value;
+
                 const res = await fetch(`/api/question/${questionText}`);
 
                 if (!res.ok) {
@@ -56,11 +73,16 @@
 
                 const matches = data.matches;
 
-                suggestionTableBody = document.getElementById("suggestiontable");
+                suggestionTableBody =
+                    document.getElementById("suggestiontable");
 
                 suggestionTableBody.innerHTML = "";
 
                 for (let i = 0; i < matches.length; i++) {
+                    if (matches[i].similarity < similaritySliderValue) {
+                        break;
+                    }
+
                     let suggestionRowElement = document.createElement("tr");
 
                     let suggestionTextElement = document.createElement("td");
@@ -76,12 +98,25 @@
                 }
             }
 
-            function onQuestionInputChange() {
+            function queueFetch() {
                 if (fetchSuggestionsTimeout) {
                     clearTimeout(fetchSuggestionsTimeout);
                 }
 
                 fetchSuggestionsTimeout = setTimeout(fetchSuggestions, 190);
+            }
+
+            function onQuestionInputChange() {
+                queueFetch();
+            }
+
+            function onSimilaritySliderChange() {
+                const slider = document.getElementById("similarity-slider");
+                const sliderLabel = document.getElementById("slider-label");
+
+                sliderLabel.innerHTML = Math.round(slider.value * 100) / 100;
+
+                queueFetch();
             }
 
             fetchSuggestions();

--- a/frontend/debug.html
+++ b/frontend/debug.html
@@ -62,14 +62,14 @@
 
                 suggestionTableBody.innerHTML = "";
 
-                for (let i = 1; i <= matches.length; i++) {
+                for (let i = 0; i < matches.length; i++) {
                     let suggestionRowElement = document.createElement("tr");
 
                     let suggestionTextElement = document.createElement("td");
-                    suggestionTextElement.innerHTML = matches[i];
+                    suggestionTextElement.innerHTML = matches[i].question;
 
                     let cosineElement = document.createElement("td");
-                    cosineElement.innerHTML = Math.random();
+                    cosineElement.innerHTML = matches[i].similarity;
 
                     suggestionRowElement.appendChild(suggestionTextElement);
                     suggestionRowElement.appendChild(cosineElement);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -62,9 +62,9 @@
                     suggestionCardElement.innerHTML = "";
 
                     const num = 10;
-                    for (let i = 1; i <= num; i++) {
+                    for (let i = 0; i < num; i++) {
                         let suggestionElement = document.createElement("div");
-                        suggestionElement.innerHTML = matches[i];
+                        suggestionElement.innerHTML = matches[i].question;
                         suggestionElement.classList.add("suggestion");
                         suggestionElement.onclick = () => onSuggestionClick(i);
 

--- a/qna/src/app/domain/doc2vec.py
+++ b/qna/src/app/domain/doc2vec.py
@@ -4,9 +4,8 @@ from gensim.models.doc2vec import Doc2Vec
 from nltk.tokenize import word_tokenize
 from scipy.spatial.distance import cosine
 import operator
-import numpy as np
 
-from typing import List
+from typing import List, Tuple
 
 
 class Doc2Vec(AbstractQuestionMatcher):
@@ -23,7 +22,7 @@ class Doc2Vec(AbstractQuestionMatcher):
         '''
         self.__questions = questions
 
-    def getSuggestions(self, question: str) -> List[str]:
+    def getSuggestions(self, question: str) -> List[Tuple[str, float]]:
         '''
         Determines question suggestions for a given question, based on the 
         similarity of their subject-line.

--- a/qna/src/app/domain/doc2vec.py
+++ b/qna/src/app/domain/doc2vec.py
@@ -61,4 +61,4 @@ class Doc2Vec(AbstractQuestionMatcher):
         sim_dict = sorted(sim_dict.items(),
                           key=operator.itemgetter(1), reverse=True)
 
-        return [k[0] for k in sim_dict]
+        return sim_dict

--- a/qna/src/app/domain/keywordmatcher.py
+++ b/qna/src/app/domain/keywordmatcher.py
@@ -37,4 +37,4 @@ class KeywordMatcher(AbstractQuestionMatcher):
             if (question != None):
                 suggestions.append(question)
 
-        return suggestions
+        return [(suggestion, 1.0) for suggestion in suggestions]

--- a/qna/src/app/domain/keywordmatcher.py
+++ b/qna/src/app/domain/keywordmatcher.py
@@ -1,5 +1,5 @@
 from .questionmatcher import AbstractQuestionMatcher
-from typing import List
+from typing import List, Tuple
 
 
 class KeywordMatcher(AbstractQuestionMatcher):
@@ -17,7 +17,7 @@ class KeywordMatcher(AbstractQuestionMatcher):
 
         print("Keyword matcher loaded")
 
-    def getSuggestions(self, question: str) -> List[str]:
+    def getSuggestions(self, question: str) -> List[Tuple[str, float]]:
         '''
         Given a question, determines which question subjects contain the same 
         keywords and should be suggested.

--- a/qna/src/app/domain/questionmatcher.py
+++ b/qna/src/app/domain/questionmatcher.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import List
+from typing import List, Tuple
 
 
 class AbstractQuestionMatcher(ABC):
@@ -9,5 +9,5 @@ class AbstractQuestionMatcher(ABC):
     all abstract methods."""
 
     @abstractmethod
-    def getSuggestions(self, question: str) -> List[str]:
+    def getSuggestions(self, question: str) -> List[Tuple[str, float]]:
         pass

--- a/qna/src/app/domain/sent_BERT.py
+++ b/qna/src/app/domain/sent_BERT.py
@@ -46,8 +46,8 @@ class SentBERT(AbstractQuestionMatcher):
             similarity_dict[self.__question_list[i]] = 1 - \
                 cosine(sentence_embedding, query_embedding)
 
-        # Order dicitonary to a list, such that higher cosine are first
+        # Order dictionary to a list, such that higher cosine are first
         similarity_dict = sorted(similarity_dict.items(),
                                  key=operator.itemgetter(1), reverse=True)
 
-        return [k[0] for k in similarity_dict]
+        return similarity_dict

--- a/qna/src/app/domain/sent_BERT.py
+++ b/qna/src/app/domain/sent_BERT.py
@@ -4,7 +4,7 @@ from sentence_transformers import SentenceTransformer
 from scipy.spatial.distance import cosine
 import operator
 
-from typing import List
+from typing import List, Tuple
 
 class SentBERT(AbstractQuestionMatcher):
     '''
@@ -23,7 +23,7 @@ class SentBERT(AbstractQuestionMatcher):
         self.__question_list = list(questions.keys())
         self.__sentence_embeddings = self.__model.encode(self.__question_list)
 
-    def getSuggestions(self, question: str) -> List[str]:
+    def getSuggestions(self, question: str) -> List[Tuple[str, float]]:
         '''
         Determines question suggestions for a given question, based on the 
         similarity of their subject-line.

--- a/qna/src/app/domain/universalencoder.py
+++ b/qna/src/app/domain/universalencoder.py
@@ -56,4 +56,4 @@ class UniversalEncoder(AbstractQuestionMatcher):
         similarity_dict = sorted(similarity_dict.items(),
                                  key=operator.itemgetter(1), reverse=True)
 
-        return [k[0] for k in similarity_dict]
+        return similarity_dict

--- a/qna/src/app/domain/universalencoder.py
+++ b/qna/src/app/domain/universalencoder.py
@@ -5,7 +5,7 @@ import tensorflow_hub as hub
 from scipy.spatial.distance import cosine
 import operator
 
-from typing import List
+from typing import List, Tuple
 
 
 class UniversalEncoder(AbstractQuestionMatcher):
@@ -29,7 +29,7 @@ class UniversalEncoder(AbstractQuestionMatcher):
         #self.__sentence_embeddings = self.__model(self.__question_list)
 
 
-    def getSuggestions(self, question: str) -> List[str]:
+    def getSuggestions(self, question: str) -> List[Tuple[str, float]]:
         '''
         Determines question suggestions for a given question, based on the 
         similarity of their subject-line.

--- a/qna/src/app/interface/web.py
+++ b/qna/src/app/interface/web.py
@@ -35,9 +35,15 @@ class MyServer(BaseHTTPRequestHandler):
         print(f"Got {len(suggestions)} suggestions")
 
         response = {
-            "matches": suggestions,
+            "matches": [],
             "question": question
         }
+
+        for suggestion in suggestions:
+            response["matches"].append({
+                "question": suggestion[0], 
+                "similarity": suggestion[1]
+            })
 
         self.send_response(200)
         self.send_header("Content-type", "application/json")


### PR DESCRIPTION
Adds a debug web ui that shows the questions and their similarity score. This view also has a slider that allows the user to tune the similarity cutoff.

![image](https://user-images.githubusercontent.com/12083577/134883633-74d30fa7-425b-4cbd-bc1f-54725f943c0e.png)

This PR also:

* Fixes missing identical suggestion bug. Turns out this was only an issue in the web UIs
* Adds .venv/ to the .ignore files
* Updates the qna docker image to download the model saving start time at the expense of image size
* Updated the various models to return a tuple of the suggestion and its similarity score
* Updated the web server to return the suggestions with the similarity score
